### PR TITLE
Use relative paths to access dependencies

### DIFF
--- a/Client/src/init.lua
+++ b/Client/src/init.lua
@@ -15,7 +15,7 @@ local Players = game:GetService("Players")
 ------------------
 -- Dependencies --
 ------------------
-local UserInput;
+local UserInput = require(script.Parent.UserInput)
 
 ------------
 -- Events --
@@ -136,7 +136,6 @@ end
 function UserInputController:Init()
 	InputSchemaChanged = self:RegisterControllerClientEvent("InputSchemaChanged")
 	DoubleTapped = self:RegisterControllerClientEvent("DoubleTapped")
-	UserInput = self:GetModule("UserInput")
 
 	CurrentInputSchema = DetermineInputSchemaFromInputType(UserInputService:GetLastInputType())
 	if CurrentInputSchema == "TouchScreen" or CurrentInputSchema == "TouchAndKeyboard" then

--- a/Client/testenv.project.json
+++ b/Client/testenv.project.json
@@ -6,7 +6,7 @@
 		"ReplicatedStorage": {
 			"$className" : "ReplicatedStorage",
 			
-			"Packages" : {"$path" : "Packages"}
+			"Packages" : {"$path" : "standalone.project.json"}
 		},
 
 		"ServerScriptService" : {
@@ -21,11 +21,7 @@
 			"StarterPlayerScripts" : {
 				"$className" : "StarterPlayerScripts",
 
-				"Controllers" : {
-					"$className" : "Folder",
-
-					"UserInputController" : {"$path" : "default.project.json"}
-				},
+				"Controllers" : {"$path" : "../TestEnv/Client/Controllers"},
 				"Scripts" : {"$path" : "../TestEnv/Client/Scripts"}
 			}
 		},

--- a/TestEnv/Client/Controllers/UserInputController.lua
+++ b/TestEnv/Client/Controllers/UserInputController.lua
@@ -1,0 +1,3 @@
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
+return require(ReplicatedStorage.Packages["userinputsystem-client"])


### PR DESCRIPTION
This PR makes a minor change to how the controller accesses the libraries it depends on. Instead of using dragon engine's `GetModule()` API, it uses a relative path `script.Parent.<library>` to access its wally-supplied dependencies.

Packages should not be making assumptions about the structure of the environment they are in, outside of what wally guarantees.